### PR TITLE
Add browser-based Tetris game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ブラウザで遊べるテトリス</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header>
+        <h1>テトリス</h1>
+        <p>矢印キーで操作し、できるだけ長くブロックを積み上げないようにしましょう。</p>
+      </header>
+      <section class="game-area">
+        <canvas id="tetris" width="240" height="480" aria-label="テトリスのプレイフィールド"></canvas>
+        <aside class="info">
+          <div class="score-board">
+            <h2>スコア</h2>
+            <p id="score">0</p>
+          </div>
+          <div class="controls">
+            <h2>操作方法</h2>
+            <ul>
+              <li>← → : ブロックを左右に移動</li>
+              <li>↑ : ブロックを回転</li>
+              <li>↓ : ブロックを素早く落下</li>
+              <li>スペース : ハードドロップ</li>
+            </ul>
+          </div>
+        </aside>
+      </section>
+    </main>
+    <script src="tetris.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,108 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #1c1c3c, #05050f 70%);
+  color: #f7f7ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.app {
+  max-width: 960px;
+  width: 100%;
+  backdrop-filter: blur(18px);
+  background: rgba(20, 20, 35, 0.7);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  padding: 2rem;
+  display: grid;
+  gap: 2rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.08em;
+}
+
+header p {
+  margin-top: 0.5rem;
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+.game-area {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+canvas {
+  background: rgba(5, 5, 15, 0.85);
+  border-radius: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.6);
+}
+
+.info {
+  display: grid;
+  gap: 1.5rem;
+  min-width: 220px;
+}
+
+.score-board h2,
+.controls h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.3rem;
+}
+
+.score-board p {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.controls ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.controls li {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .app {
+    padding: 1.5rem;
+  }
+
+  .game-area {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .info {
+    width: 100%;
+    justify-items: center;
+    text-align: center;
+  }
+}

--- a/tetris.js
+++ b/tetris.js
@@ -1,0 +1,269 @@
+const canvas = document.getElementById('tetris');
+const context = canvas.getContext('2d');
+context.scale(24, 24);
+
+const arena = createMatrix(10, 20);
+
+const colors = [
+  null,
+  '#6fffe9',
+  '#ff6f91',
+  '#ffd166',
+  '#5aa9e6',
+  '#845ef7',
+  '#06d6a0',
+  '#ef476f',
+];
+
+const player = {
+  pos: { x: 0, y: 0 },
+  matrix: null,
+  score: 0,
+};
+
+let dropCounter = 0;
+let dropInterval = 1000;
+let lastTime = 0;
+
+function arenaSweep() {
+  let rowCount = 1;
+  outer: for (let y = arena.length - 1; y >= 0; --y) {
+    for (let x = 0; x < arena[y].length; ++x) {
+      if (arena[y][x] === 0) {
+        continue outer;
+      }
+    }
+
+    const row = arena.splice(y, 1)[0].fill(0);
+    arena.unshift(row);
+    ++y;
+
+    player.score += rowCount * 100;
+    rowCount *= 2;
+
+    if (player.score > 0 && dropInterval > 200) {
+      dropInterval = Math.max(200, dropInterval - 20);
+    }
+  }
+}
+
+function collide(board, player) {
+  const [m, o] = [player.matrix, player.pos];
+  for (let y = 0; y < m.length; ++y) {
+    for (let x = 0; x < m[y].length; ++x) {
+      if (m[y][x] !== 0 && (board[y + o.y] && board[y + o.y][x + o.x]) !== 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function createMatrix(w, h) {
+  const matrix = [];
+  while (h--) {
+    matrix.push(new Array(w).fill(0));
+  }
+  return matrix;
+}
+
+function createPiece(type) {
+  switch (type) {
+    case 'T':
+      return [
+        [0, 0, 0],
+        [1, 1, 1],
+        [0, 1, 0],
+      ];
+    case 'O':
+      return [
+        [2, 2],
+        [2, 2],
+      ];
+    case 'L':
+      return [
+        [0, 3, 0],
+        [0, 3, 0],
+        [0, 3, 3],
+      ];
+    case 'J':
+      return [
+        [0, 4, 0],
+        [0, 4, 0],
+        [4, 4, 0],
+      ];
+    case 'I':
+      return [
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+      ];
+    case 'S':
+      return [
+        [0, 6, 6],
+        [6, 6, 0],
+        [0, 0, 0],
+      ];
+    case 'Z':
+      return [
+        [7, 7, 0],
+        [0, 7, 7],
+        [0, 0, 0],
+      ];
+    default:
+      throw new Error(`Unknown piece type: ${type}`);
+  }
+}
+
+function draw() {
+  context.fillStyle = '#0b0b1a';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  drawMatrix(arena, { x: 0, y: 0 });
+  drawMatrix(player.matrix, player.pos);
+}
+
+function drawMatrix(matrix, offset) {
+  matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        context.fillStyle = colors[value];
+        context.fillRect(x + offset.x, y + offset.y, 1, 1);
+
+        context.strokeStyle = 'rgba(0, 0, 0, 0.4)';
+        context.lineWidth = 0.08;
+        context.strokeRect(x + offset.x, y + offset.y, 1, 1);
+      }
+    });
+  });
+}
+
+function merge(board, player) {
+  player.matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        board[y + player.pos.y][x + player.pos.x] = value;
+      }
+    });
+  });
+}
+
+function playerDrop() {
+  player.pos.y++;
+  if (collide(arena, player)) {
+    player.pos.y--;
+    merge(arena, player);
+    playerReset();
+    arenaSweep();
+    updateScore();
+  }
+  dropCounter = 0;
+}
+
+function playerHardDrop() {
+  while (!collide(arena, player)) {
+    player.pos.y++;
+  }
+  player.pos.y--;
+  merge(arena, player);
+  playerReset();
+  arenaSweep();
+  updateScore();
+  dropCounter = 0;
+}
+
+function playerMove(dir) {
+  player.pos.x += dir;
+  if (collide(arena, player)) {
+    player.pos.x -= dir;
+  }
+}
+
+function playerReset() {
+  const pieces = 'TJLOSZI';
+  const randomType = pieces[(pieces.length * Math.random()) | 0];
+  player.matrix = createPiece(randomType);
+  player.pos.y = 0;
+  player.pos.x = ((arena[0].length / 2) | 0) - ((player.matrix[0].length / 2) | 0);
+
+  if (collide(arena, player)) {
+    arena.forEach(row => row.fill(0));
+    player.score = 0;
+    dropInterval = 1000;
+    updateScore();
+  }
+}
+
+function playerRotate(dir) {
+  const pos = player.pos.x;
+  let offset = 1;
+  rotate(player.matrix, dir);
+  while (collide(arena, player)) {
+    player.pos.x += offset;
+    offset = -(offset + (offset > 0 ? 1 : -1));
+    if (offset > player.matrix[0].length) {
+      rotate(player.matrix, -dir);
+      player.pos.x = pos;
+      return;
+    }
+  }
+}
+
+function rotate(matrix, dir) {
+  for (let y = 0; y < matrix.length; ++y) {
+    for (let x = 0; x < y; ++x) {
+      [matrix[x][y], matrix[y][x]] = [matrix[y][x], matrix[x][y]];
+    }
+  }
+
+  if (dir > 0) {
+    matrix.forEach(row => row.reverse());
+  } else {
+    matrix.reverse();
+  }
+}
+
+function update(time = 0) {
+  const deltaTime = time - lastTime;
+  lastTime = time;
+
+  dropCounter += deltaTime;
+  if (dropCounter > dropInterval) {
+    playerDrop();
+  }
+
+  draw();
+  requestAnimationFrame(update);
+}
+
+function updateScore() {
+  document.getElementById('score').innerText = player.score;
+}
+
+playerReset();
+updateScore();
+update();
+
+document.addEventListener('keydown', event => {
+  switch (event.code) {
+    case 'ArrowLeft':
+      playerMove(-1);
+      break;
+    case 'ArrowRight':
+      playerMove(1);
+      break;
+    case 'ArrowDown':
+      playerDrop();
+      break;
+    case 'ArrowUp':
+      playerRotate(1);
+      break;
+    case 'Space':
+      playerHardDrop();
+      break;
+    default:
+      return;
+  }
+  event.preventDefault();
+});


### PR DESCRIPTION
## Summary
- build a single-page layout for a browser-playable Tetris experience
- implement styling to present the playfield, score, and instructions with a futuristic theme
- add JavaScript game logic supporting movement, rotation, line clears, scoring, and speed increase

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e67de1611c8327a410bbc36f4c1188